### PR TITLE
Do not pass `None` as a filename to chameleon

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,10 +1,11 @@
 Changelog
 =========
 
-2.1 (unreleased)
-----------------
+2.1.0 (unreleased)
+------------------
 
-- Nothing changed yet.
+- Fix rendering with Chameleon 3.0 and above. See `issue 2
+  <https://github.com/zopefoundation/z3c.ptcompat/issues/2>`_.
 
 
 2.0 (2016-09-02)

--- a/src/z3c/ptcompat/engine.py
+++ b/src/z3c/ptcompat/engine.py
@@ -48,8 +48,10 @@ class Program(object):
 
     @classmethod
     def cook(cls, source_file, text, engine, content_type):
+        # Chameleon doesn't like to have a 'filename' of None;
+        # see https://github.com/zopefoundation/z3c.ptcompat/issues/2
         template = ChameleonPageTemplate(
-            text, filename=source_file, keep_body=True,
+            text, filename=source_file or '<string>', keep_body=True,
             )
 
         return cls(template), template.macros


### PR DESCRIPTION
It breaks if you do. This changed in version 3.0:
https://github.com/malthe/chameleon/commit/f642c1dfb8dae782b34769934c0ded45007d8e4c

Fixes #2.