### PR TITLE
Switch to PEP 420 native namespace.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-4.2 (unreleased)
+5.0 (unreleased)
 ----------------
 
 - Nothing changed yet.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 5.0 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Replace ``pkg_resources`` namespace with PEP 420 native namespace.
 
 
 4.1 (2025-04-09)

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@
 """
 import os
 
-from setuptools import find_packages
 from setuptools import setup
 
 
@@ -24,7 +23,10 @@ def read(*rnames):
         return f.read()
 
 
-TESTS_REQUIRE = ["zope.configuration", "zope.testing", "zope.testrunner"]
+TESTS_REQUIRE = [
+    "zope.configuration",
+    "zope.testing",
+    "zope.testrunner >= 6.4"]
 
 setup(
     name="z3c.ptcompat",
@@ -64,9 +66,6 @@ setup(
     author="Zope Foundation and Contributors",
     author_email="zope-dev@zope.dev",
     license="ZPL",
-    packages=find_packages("src"),
-    package_dir={"": "src"},
-    namespace_packages=["z3c"],
     include_package_data=True,
     zip_safe=False,
     python_requires='>=3.9',

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ TESTS_REQUIRE = ["zope.configuration", "zope.testing", "zope.testrunner"]
 
 setup(
     name="z3c.ptcompat",
-    version="4.2.dev0",
+    version="5.0.dev0",
     description="Zope-compatible page template engine based on Chameleon.",
     long_description="\n\n".join(
         (".. contents::", read("README.rst"), read("CHANGES.rst"))

--- a/src/z3c/__init__.py
+++ b/src/z3c/__init__.py
@@ -1,1 +1,0 @@
-__import__("pkg_resources").declare_namespace(__name__)  # pragma: no cover


### PR DESCRIPTION
- **Bumped version for breaking release.**
- **Replace ``pkg_resources`` namespace with PEP 420 native namespace.**
- **Update code.**
